### PR TITLE
enforce node>=10.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - '0.10'
+  - '10.12'
 
 script: "npm test"
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ## Install
 
+Needs `node >= 10.12`.
+
 ```sh
 $ npm install -g glob-run
 ```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "repository": "fahad19/glob-run",
   "license": "MIT",
   "bin": "./bin/glob-run",
+  "engines": {
+    "node": ">= 10.12.0"
+  },
   "keywords": [
     "npm",
     "scripts",


### PR DESCRIPTION
This should fix the travis-ci.
Because  we depend on `mocha` witch requires node>=10.12 we also need to enforce node>=10.12!